### PR TITLE
Fix/apple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,22 +21,50 @@ target_include_directories(jhighs PRIVATE
     ${CMAKE_SOURCE_DIR}/src/main/native/third-party/HiGHS/highs
 )
 
-target_link_libraries(jhighs
-    highs
-    ${JNI_LIBRARIES}
-)
+# Platform-specific linking
+if(APPLE)
+    # On modern macOS, don't link JavaVM framework - JNI symbols are resolved at runtime
+    target_link_libraries(jhighs
+        highs
+    )
+    # Set proper linking flags for macOS
+    set_target_properties(jhighs PROPERTIES
+        LINK_FLAGS "-undefined dynamic_lookup"
+    )
+else()
+    # On other platforms, use regular JNI libraries
+    target_link_libraries(jhighs
+        highs
+        ${JNI_LIBRARIES}
+    )
+endif()
 
-# Set output directory based on platform
+message(STATUS "JNI_LIBRARIES: ${JNI_LIBRARIES}")
+
+# Determine architecture
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+    set(ARCH_NAME "arm64")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64)$")
+    set(ARCH_NAME "x86_64")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(armv7l)$")
+    set(ARCH_NAME "armv7")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i386|i686)$")
+    set(ARCH_NAME "x86")
+else()
+    set(ARCH_NAME ${CMAKE_SYSTEM_PROCESSOR})
+endif()
+
+# Set output directory based on platform and architecture
 if(WIN32)
     set_target_properties(jhighs PROPERTIES
-        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/src/main/resources/natives/windows-x86_64
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/src/main/resources/natives/windows-${ARCH_NAME}
     )
 elseif(APPLE)
     set_target_properties(jhighs PROPERTIES
-        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/src/main/resources/natives/darwin-x86_64
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/src/main/resources/natives/darwin-${ARCH_NAME}
     )
 else()
     set_target_properties(jhighs PROPERTIES
-        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/src/main/resources/natives/linux-x86_64
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/src/main/resources/natives/linux-${ARCH_NAME}
     )
 endif()

--- a/scripts/build-native.sh
+++ b/scripts/build-native.sh
@@ -5,20 +5,41 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 BUILD_DIR="$PROJECT_ROOT/build"
 
-# Determine platform
+# Determine platform and architecture
 OS=$(uname -s)
 ARCH=$(uname -m)
+
+# Normalize architecture names
+case "$ARCH" in
+    x86_64|amd64)
+        NORM_ARCH="x86_64"
+        ;;
+    arm64|aarch64)
+        NORM_ARCH="arm64"
+        ;;
+    armv7l)
+        NORM_ARCH="armv7"
+        ;;
+    i386|i686)
+        NORM_ARCH="x86"
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+        ;;
+esac
+
 case "$OS" in
     Linux*)
-        PLATFORM="linux-x86_64"
+        PLATFORM="linux-$NORM_ARCH"
         LIB_EXT="so"
         ;;
     Darwin*)
-        PLATFORM="darwin-x86_64"
+        PLATFORM="darwin-$NORM_ARCH"
         LIB_EXT="dylib"
         ;;
     MINGW*|MSYS*|CYGWIN*)
-        PLATFORM="windows-x86_64"
+        PLATFORM="windows-$NORM_ARCH"
         LIB_EXT="dll"
         ;;
     *)
@@ -27,21 +48,16 @@ case "$OS" in
         ;;
 esac
 
-echo "Building for platform: $PLATFORM"
+echo "Building for platform: $PLATFORM (OS: $OS, Arch: $ARCH -> $NORM_ARCH)"
 
 # Create and clean build directory
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 
-# Configure and build with CMake
-cmake -DCMAKE_BUILD_TYPE=Release "$PROJECT_ROOT"
-make -j$(nproc || sysctl -n hw.ncpu || echo 4)
-
-echo "Building native library..."
-echo "$PWD"
-# Generate JNI headers
-javac -h . -cp "$PROJECT_ROOT/src/main/java" \
+# Generate JNI headers first
+echo "Generating JNI headers..."
+javac -h "$BUILD_DIR" -cp "$PROJECT_ROOT/src/main/java" \
   "$PROJECT_ROOT/src/main/java/nl/jessenagel/jhighs/HiGHS.java" \
   "$PROJECT_ROOT/src/main/java/nl/jessenagel/jhighs/VarType.java" \
   "$PROJECT_ROOT/src/main/java/nl/jessenagel/jhighs/HighsStatus.java" \
@@ -49,96 +65,148 @@ javac -h . -cp "$PROJECT_ROOT/src/main/java" \
   "$PROJECT_ROOT/src/main/java/nl/jessenagel/jhighs/Solution.java"
 echo "JNI headers generated successfully."
 
-# Create output directory
+# Configure and build with CMake
+case "$OS" in
+    Linux*)
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-fPIC" "$PROJECT_ROOT"
+        ;;
+    Darwin*)
+        # For macOS, ensure JAVA_HOME is set correctly
+        if [[ -z "$JAVA_HOME" ]]; then
+            export JAVA_HOME=$(/usr/libexec/java_home)
+            echo "JAVA_HOME set to: $JAVA_HOME"
+        fi
+
+        # Set architecture-specific flags for macOS
+        if [[ "$NORM_ARCH" == "arm64" ]]; then
+            CMAKE_ARCH_FLAGS="-DCMAKE_OSX_ARCHITECTURES=arm64"
+        elif [[ "$NORM_ARCH" == "x86_64" ]]; then
+            CMAKE_ARCH_FLAGS="-DCMAKE_OSX_ARCHITECTURES=x86_64"
+        else
+            CMAKE_ARCH_FLAGS=""
+        fi
+
+        cmake -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_CXX_FLAGS="-fPIC" \
+              -DJAVA_HOME="$JAVA_HOME" \
+              $CMAKE_ARCH_FLAGS \
+              "$PROJECT_ROOT"
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        # Windows architecture handling
+        if [[ "$NORM_ARCH" == "x86_64" ]]; then
+            cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release "$PROJECT_ROOT"
+        else
+            cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_GENERATOR_PLATFORM="$NORM_ARCH" "$PROJECT_ROOT"
+        fi
+        ;;
+    *)
+        echo "Unsupported platform: $OS"
+        exit 1
+        ;;
+esac
+
+# Build the project
+make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+
+echo "Build completed successfully!"
+
+# Create output directory if it doesn't exist
 OUTPUT_DIR="$PROJECT_ROOT/src/main/resources/natives/$PLATFORM"
 mkdir -p "$OUTPUT_DIR"
-echo "Output directory created: $OUTPUT_DIR"
-# Platform-specific compilation and copying
-case "$PLATFORM" in
-    linux-*)
-        echo "Compiling for Linux..."
-        # Compile the JNI library
-        g++ -shared -fPIC \
-            -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux \
-            -I"$PROJECT_ROOT/src/main/native/third-party/HiGHS/highs" \
-            -I"$PROJECT_ROOT/build/src/main/native/third-party/HiGHS" \
-            -L"$PROJECT_ROOT/build/lib64" \
-            -L"$PROJECT_ROOT/build/lib" \
-            -lhighs \
-            "$PROJECT_ROOT/src/main/native/cpp/highs_jni.cpp" \
-            -o libhighs_jni.so
-        echo "Compilation complete."
-        # Copy JNI library
-        cp libhighs_jni.so "$OUTPUT_DIR/"
 
+# Copy HiGHS libraries to output directory
+echo "Copying HiGHS libraries..."
 
-        # Copy HiGHS libraries
-        if [[ -f "$PROJECT_ROOT/build/lib64/libhighs.so" ]]; then
-            cp "$PROJECT_ROOT/build/lib64/libhighs.so" "$OUTPUT_DIR/"
-        elif [[ -f "$PROJECT_ROOT/build/lib/libhighs.so" ]]; then
-            cp "$PROJECT_ROOT/build/lib/libhighs.so" "$OUTPUT_DIR/"
-        fi
+# Function to copy library files
+copy_libs() {
+    local lib_dir="$1"
+    local lib_ext="$2"
 
-        if [[ -f "$PROJECT_ROOT/build/lib64/libhighs.so.1" ]]; then
-            cp "$PROJECT_ROOT/build/lib64/libhighs.so.1" "$OUTPUT_DIR/"
-        elif [[ -f "$PROJECT_ROOT/build/lib/libhighs.so.1" ]]; then
-            cp "$PROJECT_ROOT/build/lib/libhighs.so.1" "$OUTPUT_DIR/"
-        fi
+    if [[ -d "$lib_dir" ]]; then
+        echo "Checking for libraries in: $lib_dir"
 
-        if [[ -f "$PROJECT_ROOT/build/lib64/libhighs.so.1.11.0" ]]; then
-            cp "$PROJECT_ROOT/build/lib64/libhighs.so.1.11.0" "$OUTPUT_DIR/"
-        elif [[ -f "$PROJECT_ROOT/build/lib/libhighs.so.1.11.0" ]]; then
-            cp "$PROJECT_ROOT/build/lib/libhighs.so.1.11.0" "$OUTPUT_DIR/"
-        fi
+        case "$OS" in
+            Darwin*)
+                # macOS - copy .dylib files
+                if [[ -f "$lib_dir/libhighs.$lib_ext" ]]; then
+                    cp "$lib_dir/libhighs.$lib_ext" "$OUTPUT_DIR/"
+                    echo "Copied libhighs.$lib_ext"
+                fi
+                if [[ -f "$lib_dir/libhighs.1.$lib_ext" ]]; then
+                    cp "$lib_dir/libhighs.1.$lib_ext" "$OUTPUT_DIR/"
+                    echo "Copied libhighs.1.$lib_ext"
+                fi
+                if [[ -f "$lib_dir/libhighs.1.11.$lib_ext" ]]; then
+                    cp "$lib_dir/libhighs.1.11.$lib_ext" "$OUTPUT_DIR/"
+                    echo "Copied libhighs.1.11.$lib_ext"
+                fi
+                ;;
+            Linux*)
+                # Linux - copy .so files
+                if [[ -f "$lib_dir/libhighs.$lib_ext" ]]; then
+                    cp "$lib_dir/libhighs.$lib_ext" "$OUTPUT_DIR/"
+                    echo "Copied libhighs.$lib_ext"
+                fi
+                if [[ -f "$lib_dir/libhighs.$lib_ext.1" ]]; then
+                    cp "$lib_dir/libhighs.$lib_ext.1" "$OUTPUT_DIR/"
+                    echo "Copied libhighs.$lib_ext.1"
+                fi
+                if [[ -f "$lib_dir/libhighs.$lib_ext.1.11.0" ]]; then
+                    cp "$lib_dir/libhighs.$lib_ext.1.11.0" "$OUTPUT_DIR/"
+                    echo "Copied libhighs.$lib_ext.1.11.0"
+                fi
+                ;;
+            MINGW*|MSYS*|CYGWIN*)
+                # Windows - copy .dll files
+                if [[ -f "$lib_dir/highs.$lib_ext" ]]; then
+                    cp "$lib_dir/highs.$lib_ext" "$OUTPUT_DIR/"
+                    echo "Copied highs.$lib_ext"
+                fi
+                if [[ -f "$lib_dir/libhighs.$lib_ext" ]]; then
+                    cp "$lib_dir/libhighs.$lib_ext" "$OUTPUT_DIR/"
+                    echo "Copied libhighs.$lib_ext"
+                fi
+                ;;
+        esac
+    fi
+}
 
-        MAIN_LIB="libhighs_jni.so"
+# Try different library directories based on architecture
+case "$NORM_ARCH" in
+    x86_64|amd64)
+        # Try lib64 first, then lib
+        copy_libs "$PROJECT_ROOT/build/lib64" "$LIB_EXT"
+        copy_libs "$PROJECT_ROOT/build/lib" "$LIB_EXT"
         ;;
-
-    darwin-*)
-        echo "Compiling for macOS..."
-        g++ -shared -fPIC \
-            -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin \
-            -I"$PROJECT_ROOT/src/main/native/third-party/HiGHS/highs" \
-            -I"$PROJECT_ROOT/build/src/main/native/third-party/HiGHS" \
-            -L"$PROJECT_ROOT/build/lib" \
-            -lhighs "$PROJECT_ROOT/src/main/native/cpp/highs_jni.cpp" \
-            -o libjhighs.dylib
-
-        cp libjhighs.dylib "$OUTPUT_DIR/"
-        if [[ -f "$PROJECT_ROOT/build/lib/libhighs.dylib" ]]; then
-            cp "$PROJECT_ROOT/build/lib/libhighs.dylib" "$OUTPUT_DIR/"
-        fi
-
-        MAIN_LIB="libjhighs.dylib"
-        ;;
-
-    windows-*)
-        echo "Compiling for Windows..."
-        g++ -shared \
-            -I"${JAVA_HOME}/include" -I"${JAVA_HOME}/include/win32" \
-            -I"$PROJECT_ROOT/src/main/native/third-party/HiGHS/highs" \
-            -I"$PROJECT_ROOT/build/src/main/native/third-party/HiGHS" \
-            -L"$PROJECT_ROOT/build/lib" \
-            -lhighs "$PROJECT_ROOT/src/main/native/cpp/highs_jni.cpp" \
-            -o jhighs.dll
-
-        cp jhighs.dll "$OUTPUT_DIR/"
-        if [[ -f "$PROJECT_ROOT/build/lib/highs.dll" ]]; then
-            cp "$PROJECT_ROOT/build/lib/highs.dll" "$OUTPUT_DIR/"
-        fi
-
-        MAIN_LIB="jhighs.dll"
+    *)
+        # For other architectures, try lib first, then lib64
+        copy_libs "$PROJECT_ROOT/build/lib" "$LIB_EXT"
+        copy_libs "$PROJECT_ROOT/build/lib64" "$LIB_EXT"
         ;;
 esac
 
 # Verify the library was created
-if [[ ! -f "$BUILD_DIR/$MAIN_LIB" ]]; then
-    echo "Error: $MAIN_LIB not found in $BUILD_DIR"
+case "$OS" in
+    Linux*)
+        MAIN_LIB="libjhighs.so"
+        ;;
+    Darwin*)
+        MAIN_LIB="libjhighs.dylib"
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        MAIN_LIB="jhighs.dll"
+        ;;
+esac
+
+if [[ ! -f "$OUTPUT_DIR/$MAIN_LIB" ]]; then
+    echo "Error: $MAIN_LIB not found in $OUTPUT_DIR"
+    echo "Contents of $OUTPUT_DIR:"
+    ls -la "$OUTPUT_DIR" 2>/dev/null || echo "Directory does not exist"
     exit 1
 fi
 
-echo "Native library built successfully: $BUILD_DIR/$MAIN_LIB"
-echo "Libraries copied to: $OUTPUT_DIR"
+echo "Native library built successfully: $OUTPUT_DIR/$MAIN_LIB"
 
 # List all files in output directory
 echo "Files in output directory:"

--- a/src/main/java/nl/jessenagel/jhighs/NativeLibraryLoader.java
+++ b/src/main/java/nl/jessenagel/jhighs/NativeLibraryLoader.java
@@ -69,7 +69,9 @@ public class NativeLibraryLoader {
     private static String[] getLibraryNames(String platform) {
         switch (platform) {
             case "linux-x86_64":
+            case "linux-arm64":
                 return new String[]{"libhighs.so", "libhighs_jni.so"};
+            case "darwin-arm64":
             case "darwin-x86_64":
                 return new String[]{"libhighs.dylib", "libjhighs.dylib"};
             case "windows-x86_64":
@@ -95,12 +97,6 @@ public class NativeLibraryLoader {
 
             System.out.println("Extracting " + libName + " to " + libFile);
 
-            try {
-                LddRunner.runLdd(libFile.toAbsolutePath().toString());
-            } catch (InterruptedException e) {
-                // Just log this, don't fail
-                System.err.println("LDD check interrupted: " + e.getMessage());
-            }
 
             // If this is the first library (libhighs.so), set LD_LIBRARY_PATH to include temp directory
             if (libName.equals("libhighs.so")) {
@@ -113,21 +109,4 @@ public class NativeLibraryLoader {
         }
     }
 
-    public static class LddRunner {
-        public static void runLdd(String libPath) throws IOException, InterruptedException {
-            ProcessBuilder pb = new ProcessBuilder("ldd", libPath);
-            pb.redirectErrorStream(true);
-            Process process = pb.start();
-
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    System.out.println(line);
-                }
-            }
-            int exitCode = process.waitFor();
-            System.out.println("ldd exited with code: " + exitCode);
-        }
-    }
 }


### PR DESCRIPTION
This pull request introduces platform-specific adjustments and architecture normalization for better compatibility across macOS, Linux, and Windows. It also simplifies native library handling and removes unused code related to dependency checks. The most important changes include architecture detection, platform-specific build configurations, and cleanup of redundant code.

### Platform-specific adjustments:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR24-R68): Added platform-specific linking and architecture detection to ensure proper handling of macOS and other platforms. Updated output directory paths to include normalized architecture names.
* [`scripts/build-native.sh`](diffhunk://#diff-912a856a924786aa30dc33666a6fbd91ae64c39712c94e7db951c11a6f9d7047L8-R42): Enhanced platform and architecture detection, normalized architecture names, and added platform-specific build configurations for Linux, macOS, and Windows. Improved library copying logic with a new function. [[1]](diffhunk://#diff-912a856a924786aa30dc33666a6fbd91ae64c39712c94e7db951c11a6f9d7047L8-R42) [[2]](diffhunk://#diff-912a856a924786aa30dc33666a6fbd91ae64c39712c94e7db951c11a6f9d7047L30-R209)

### Code cleanup:
* [`src/main/java/nl/jessenagel/jhighs/NativeLibraryLoader.java`](diffhunk://#diff-8bd1cdaf38598121bfbc4e4538ea69dfc9aac2dda3605f62eb6af9b0afdbdab0L98-L103): Removed `LddRunner` class and its invocation, as it causes errors on MacOS, simplifying the library loading process. [[1]](diffhunk://#diff-8bd1cdaf38598121bfbc4e4538ea69dfc9aac2dda3605f62eb6af9b0afdbdab0L98-L103) [[2]](diffhunk://#diff-8bd1cdaf38598121bfbc4e4538ea69dfc9aac2dda3605f62eb6af9b0afdbdab0L116-L132)

### Compatibility improvements:
* [`src/main/java/nl/jessenagel/jhighs/NativeLibraryLoader.java`](diffhunk://#diff-8bd1cdaf38598121bfbc4e4538ea69dfc9aac2dda3605f62eb6af9b0afdbdab0R72-R74): Added support for new architecture names (`linux-arm64` and `darwin-arm64`) in native library loading logic.