### PR TITLE
Update library names in NativeLibraryLoader and increment version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.jessenagel.optimization</groupId>
     <artifactId>jhighs</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/nl/jessenagel/jhighs/NativeLibraryLoader.java
+++ b/src/main/java/nl/jessenagel/jhighs/NativeLibraryLoader.java
@@ -69,7 +69,7 @@ public class NativeLibraryLoader {
     private static String[] getLibraryNames(String platform) {
         switch (platform) {
             case "linux-x86_64":
-                return new String[]{"libhighs.so", "libhighs_jni.so"};
+                return new String[]{"libhighs.so", "libjhighs.so"};
             case "darwin-x86_64":
                 return new String[]{"libhighs.dylib", "libjhighs.dylib"};
             case "windows-x86_64":


### PR DESCRIPTION
This pull request includes a version update for the `jhighs` artifact and a modification to the native library names in the `NativeLibraryLoader` class to align with naming conventions.

### Dependency Update:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9): Updated the `jhighs` artifact version from `0.1.0` to `0.1.1` to include the latest changes or fixes.

### Native Library Naming Adjustment:
* [`src/main/java/nl/jessenagel/jhighs/NativeLibraryLoader.java`](diffhunk://#diff-8bd1cdaf38598121bfbc4e4538ea69dfc9aac2dda3605f62eb6af9b0afdbdab0L72-R72): Changed the library name for the `linux-x86_64` platform from `libhighs_jni.so` to `libjhighs.so` to standardize naming conventions.