### PR TITLE
Create trigger-maven.yml

### DIFF
--- a/.github/workflows/trigger-maven.yml
+++ b/.github/workflows/trigger-maven.yml
@@ -1,0 +1,30 @@
+name: Trigger Maven Repository Update
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  trigger-maven-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get release info
+      id: release
+      run: |
+        echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        echo "SUBMODULE=${GITHUB_REPOSITORY##*/}" >> $GITHUB_OUTPUT
+
+    - name: Trigger Optimization repository deployment
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.OPTIMIZATION_REPO_TOKEN }}
+        repository: ${{ github.repository_owner }}/Optimization
+        event-type: submodule-release
+        client-payload: |
+          {
+            "submodule": "${{ steps.release.outputs.SUBMODULE }}",
+            "version": "${{ steps.release.outputs.VERSION }}",
+            "repository": "${{ github.repository }}",
+            "release_url": "${{ github.event.release.html_url }}"
+          }


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of triggering updates to the Maven repository upon a release. The workflow ensures that submodule releases are properly communicated to the `Optimization` repository.

### New GitHub Actions Workflow:

* [`.github/workflows/trigger-maven.yml`](diffhunk://#diff-7a5f769523dc89c9133abdf0cf225ddbfaee991dc659ceee0483bb055b35f12fR1-R30): Added a new workflow named "Trigger Maven Repository Update" that runs on `release` events (of type `published`) or can be manually triggered via `workflow_dispatch`. The workflow extracts release information (version and submodule) and triggers a deployment in the `Optimization` repository using the `repository-dispatch` action.