### PR TITLE
Add temporary directory management and cleanup for native libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ target/
 *.iml
 *.ipr
 .idea
+vcs.xml
 
 ### Eclipse ###
 .apt_generated

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/src/main/native/third-party/HiGHS" vcs="Git" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/src/main/native/third-party/HiGHS" vcs="Git" />
-  </component>
-</project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.jessenagel.optimization</groupId>
     <artifactId>jhighs</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality and maintainability of the `jhighs` project. The key updates include adding cleanup for temporary directories used during native library loading, improving platform-specific library handling, and updating the project version. Below is a categorized summary of the most important changes:

### Native Library Loading Enhancements:
* Introduced a `tempDir` field in `NativeLibraryLoader` to manage temporary directories for native libraries and added a shutdown hook to clean up the directory after the application exits. (`src/main/java/nl/jessenagel/jhighs/NativeLibraryLoader.java`) [[1]](diffhunk://#diff-8bd1cdaf38598121bfbc4e4538ea69dfc9aac2dda3605f62eb6af9b0afdbdab0R9) [[2]](diffhunk://#diff-8bd1cdaf38598121bfbc4e4538ea69dfc9aac2dda3605f62eb6af9b0afdbdab0L22-R26)
* Added a `cleanupTempDirectory` method to safely delete the temporary directory and its contents, ensuring proper resource cleanup. (`src/main/java/nl/jessenagel/jhighs/NativeLibraryLoader.java`)

### Code Simplifications:
* Refactored the `getLibraryNames` method to use a `switch` expression, simplifying the logic for determining platform-specific library names. (`src/main/java/nl/jessenagel/jhighs/NativeLibraryLoader.java`)

### Project Configuration Updates:
* Updated the project version in `pom.xml` from `0.1.1` to `0.1.2`. (`pom.xml`)
* Added a new Git mapping for the `HiGHS` third-party directory in the `.idea/vcs.xml` configuration file. (`.idea/vcs.xml`)